### PR TITLE
Fix build issue after migrate SDK v51

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "expo-linking": "~6.3.1",
     "expo-location": "~17.0.1",
     "expo-notifications": "~0.28.16",
-    "expo-permissions": "~14.2.1",
     "expo-status-bar": "~1.12.1",
     "expo-task-manager": "~11.8.2",
     "expo-tracking-transparency": "~4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3385,11 +3385,6 @@ expo-notifications@~0.28.16:
     expo-constants "~16.0.0"
     fs-extra "^9.1.0"
 
-expo-permissions@~14.2.1:
-  version "14.2.1"
-  resolved "https://registry.yarnpkg.com/expo-permissions/-/expo-permissions-14.2.1.tgz#da4a7ef45e13da99032960528267cc9ca8e964b8"
-  integrity sha512-jXGnOODtDMFvK7cwo7wIRPcnA7m1bie80gJ5BdL6Vs5kgCU7+RCLOCp3sBw7TKRPIlVMmQDhZA62bGzoBV0hkA==
-
 expo-status-bar@~1.12.1:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.12.1.tgz#52ce594aab5064a0511d14375364d718ab78aa66"


### PR DESCRIPTION
`expo-permission` is no longer supported in v51. And I found `expo-permission` is not used. 
This PR is to remove the dependency from the project. 
I tried it with my testing expo project. It was able to be built now.