### PR TITLE
Update zhhant app name

### DIFF
--- a/locales/zh-Hant.json
+++ b/locales/zh-Hant.json
@@ -1,4 +1,4 @@
 {
-    "CFBundleDisplayName": "巴士到站預報",
-    "app_name": "巴士到站預報"
+    "CFBundleDisplayName": "巴士預報",
+    "app_name": "巴士預報"
 }


### PR DESCRIPTION
Since the zh app name was too long on iOS and truncated by the system, now it is updated to "巴士預報".