### PR TITLE
fix white blink at app start

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,5 @@
 import "react-native-url-polyfill/auto";
+import * as SplashScreen from "expo-splash-screen";
 import React, {
   useCallback,
   useEffect,
@@ -14,10 +15,8 @@ import {
   Linking,
   Platform,
   StyleSheet,
-  ImageBackground,
   Share,
   ToastAndroid,
-  View,
 } from "react-native";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import {
@@ -38,6 +37,8 @@ import {
 import { postAlarmToWebView, toggleAlarm } from "./stopAlarm";
 import * as ExpoLinking from "expo-linking";
 import AsyncStorage from '@react-native-async-storage/async-storage';
+
+SplashScreen.preventAutoHideAsync();
 
 export default function App() {
   const url = ExpoLinking.useURL();
@@ -273,15 +274,7 @@ export default function App() {
   }, []);
 
   if (!readyToLoad) {
-    return (
-      <ImageBackground
-        source={require("./assets/splash.png")}
-        style={{
-          width: "100%",
-          height: "100%",
-        }}
-      />
-    );
+    return <></>;
   }
 
   const uri = url?.startsWith("https://hkbus.app") ? url : "https://hkbus.app/";
@@ -310,8 +303,8 @@ export default function App() {
             onContentProcessDidTerminate={handleContentTerminate}
             bounces={false}
             onNavigationStateChange={handleWebViewNavigationStateChange}
-            renderLoading={() => <View style={styles.loadingView} />}
-            startInLoadingState={true}
+            onLoadEnd={() => SplashScreen.hideAsync()}
+            startInLoadingState
           />
         </SafeAreaView>
       </SafeAreaProvider>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "expo-linking": "~6.3.1",
     "expo-location": "~17.0.1",
     "expo-notifications": "~0.28.16",
+    "expo-splash-screen": "~0.27.7",
     "expo-status-bar": "~1.12.1",
     "expo-task-manager": "~11.8.2",
     "expo-tracking-transparency": "~4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,6 +1205,11 @@
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-51.0.2.tgz#7385451b180d34d8f2a4eeb5feabe1fe3c5d4f32"
   integrity sha512-IglkIoiDwJMY01lYkF/ZSBoe/5cR+O3+Gx6fpLFjLfgZGBTdyPkKa1g8NWoWQCk+D3cKL2MDbszT2DyRRB0YqQ==
 
+"@expo/config-types@^51.0.3":
+  version "51.0.3"
+  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-51.0.3.tgz#520bdce5fd75f9d234fd81bd0347443086419450"
+  integrity sha512-hMfuq++b8VySb+m9uNNrlpbvGxYc8OcFCUX9yTmi9tlx6A4k8SDabWFBgmnr4ao3wEArvWrtUQIfQCVtPRdpKA==
+
 "@expo/config@9.0.3", "@expo/config@~9.0.0", "@expo/config@~9.0.0-beta.0":
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/@expo/config/-/config-9.0.3.tgz#4bc2ec654145e6242f4b1964db2962ee0fee1270"
@@ -1358,6 +1363,23 @@
     "@expo/config" "~9.0.0-beta.0"
     "@expo/config-plugins" "~8.0.8"
     "@expo/config-types" "^51.0.0-unreleased"
+    "@expo/image-utils" "^0.5.0"
+    "@expo/json-file" "^8.3.0"
+    "@react-native/normalize-colors" "0.74.85"
+    debug "^4.3.1"
+    fs-extra "^9.0.0"
+    resolve-from "^5.0.0"
+    semver "^7.6.0"
+    xml2js "0.6.0"
+
+"@expo/prebuild-config@7.0.9":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@expo/prebuild-config/-/prebuild-config-7.0.9.tgz#7abd489e18ed6514a0c9cd214eb34c0d5efda799"
+  integrity sha512-9i6Cg7jInpnGEHN0jxnW0P+0BexnePiBzmbUvzSbRXpdXihYUX2AKMu73jgzxn5P1hXOSkzNS7umaY+BZ+aBag==
+  dependencies:
+    "@expo/config" "~9.0.0-beta.0"
+    "@expo/config-plugins" "~8.0.8"
+    "@expo/config-types" "^51.0.3"
     "@expo/image-utils" "^0.5.0"
     "@expo/json-file" "^8.3.0"
     "@react-native/normalize-colors" "0.74.85"
@@ -3384,6 +3406,13 @@ expo-notifications@~0.28.16:
     expo-application "~5.9.0"
     expo-constants "~16.0.0"
     fs-extra "^9.1.0"
+
+expo-splash-screen@~0.27.7:
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/expo-splash-screen/-/expo-splash-screen-0.27.7.tgz#52171be54d8c008880d928e802819d767fbd3c12"
+  integrity sha512-s+eGcG185878nixlrjhhLD6UDYrvoqBUaBkIEozBVWFg3pkdsKpONPiUAco4XR3h7I/9ODq4quN28RJLFO+s0Q==
+  dependencies:
+    "@expo/prebuild-config" "7.0.9"
 
 expo-status-bar@~1.12.1:
   version "1.12.1"


### PR DESCRIPTION
This PR removes 1 white flash at app start.
https://t.me/hkbusapp/36764

Only tested with Expo Go Android & iOS. Not tested with development builds or release builds.

Left: Before
Right: After
Recorded in Pixel 8 API 35 (Android 15) Android Emulator
It is not expected that the webpage will be rendered sooner after this PR. Should merely be an intermittent device performance difference.

https://github.com/user-attachments/assets/7f4c54db-3edd-483a-b9bb-b88b77f930d4
