### PR TITLE
fix android overscroll

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -309,6 +309,7 @@ export default function App() {
             }}
             onContentProcessDidTerminate={handleContentTerminate}
             bounces={false}
+            overScrollMode="content"
             onNavigationStateChange={handleWebViewNavigationStateChange}
             renderLoading={() => <View style={styles.loadingView} />}
             startInLoadingState={true}


### PR DESCRIPTION
This PR removes the Android over scroll effect when nothing at the top level of the app actually can be scrolled

Before:
![image](https://github.com/user-attachments/assets/7bcfe689-fd8f-45d1-a8ed-62897fd2447b)
