### PR TITLE
Fix geolocation not updated after app resume

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -81,7 +81,7 @@ module.exports = ({ config }: ConfigContext): ExpoConfig => {
       associatedDomains: [
         'applinks:hkbus.app'
       ],
-      buildNumber: '12'
+      buildNumber: '13'
     },
     android: {
       adaptiveIcon: {


### PR DESCRIPTION
Try to fix it by restarting the location watcher when the app resumes.